### PR TITLE
Export ProviderClass type for consumer utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "roboot",
-  "version": "2.0.1",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roboot",
-      "version": "2.0.1",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.1",
-        "@types/node": "^22.5.1",
         "husky": "^8.0.3",
         "jest": "^29.5.0",
         "lint-staged": "^13.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roboot",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A dependency injection library with support for circular dependencies and async initialization",
   "main": "dist/roboot.js",
   "typings": "dist/roboot.d.ts",

--- a/roboot.ts
+++ b/roboot.ts
@@ -12,7 +12,9 @@ interface IProvider<T> {
   provide(): T;
 }
 
-type ProviderClass<T = unknown> = new (container: Container) => IProvider<T>;
+export type ProviderClass<T = unknown> = new (
+  container: Container
+) => IProvider<T>;
 
 type UnresolvedCircular = {
   temp: Object;


### PR DESCRIPTION
I've run into several instances where it would be useful to have access to the ProviderClass type as a consumer when doing more abstract programming using this library, so this PR simply patches the library to export that type.